### PR TITLE
feat: Add Transaction Confirmation Modal for Contributions and Claims

### DIFF
--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -1,11 +1,33 @@
 "use client";
 
-import { useMemo } from "react";
+import { useMemo, useState } from "react";
 import { ArrowUpRight, Users, CheckCircle2, DollarSign } from "lucide-react";
 import SavingsCard from "@/components/cards/SavingsCard";
+import TxConfirmModal, { TxType } from "@/components/modals/TxConfirmModal";
 import type { Circle } from "@/types/circle";
 
+interface PendingTx {
+  type: TxType;
+  circle: Circle;
+  amount: number;
+}
+
+/**
+ * contributionButtonLabel looks like "Make Contribution (50 USDT)".
+ * Pulls the numeric amount out so the modal can display/use a clean number.
+ * Falls back to parsing `circle.contribution` (e.g. "40 USDT") if that fails.
+ */
+function getContributionAmount(circle: Circle): number {
+  const fromLabel = circle.contributionButtonLabel.match(/([\d.]+)\s*USDT/i);
+  if (fromLabel) return parseFloat(fromLabel[1]);
+
+  const fromContribution = circle.contribution.match(/([\d.]+)/);
+  return fromContribution ? parseFloat(fromContribution[1]) : 0;
+}
+
 export default function DashboardOverviewPage() {
+  const [pendingTx, setPendingTx] = useState<PendingTx | null>(null);
+
   const deadlines = useMemo(
     () => ({
       card1: new Date(Date.now() + 25 * 60 * 1000),
@@ -82,6 +104,38 @@ export default function DashboardOverviewPage() {
     [deadlines]
   );
 
+  const handleContributeClick = (circle: Circle) => {
+    setPendingTx({
+      type: "contribute",
+      circle,
+      amount: getContributionAmount(circle),
+    });
+  };
+
+  const handleClaimClick = (circle: Circle) => {
+    // TODO: replace with the real claimable amount once available on Circle
+    setPendingTx({
+      type: "claim",
+      circle,
+      amount: getContributionAmount(circle),
+    });
+  };
+
+  // Replace these stubs with real contract/service calls (e.g. starknet.js)
+  const submitContribution = async (circle: Circle, amount: number): Promise<string> => {
+    await new Promise((resolve) => setTimeout(resolve, 1500));
+    // const tx = await contract.contribute(circle.id, amount);
+    // return tx.transaction_hash;
+    return "0x0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcd";
+  };
+
+  const submitClaim = async (circle: Circle): Promise<string> => {
+    await new Promise((resolve) => setTimeout(resolve, 1500));
+    // const tx = await contract.claim(circle.id);
+    // return tx.transaction_hash;
+    return "0xabcdef0123456789abcdef0123456789abcdef0123456789abcdef01234567";
+  };
+
   return (
     <div className="space-y-10 pb-20 md:pb-0">
       {/* Top Stats Cards */}
@@ -155,10 +209,30 @@ export default function DashboardOverviewPage() {
 
         <div className="space-y-4">
           {circles.map((circle) => (
-            <SavingsCard key={circle.id} circle={circle} />
+            <SavingsCard
+              key={circle.id}
+              circle={circle}
+              onContribute={handleContributeClick}
+              onClaim={handleClaimClick}
+            />
           ))}
         </div>
       </div>
+
+      {pendingTx && (
+        <TxConfirmModal
+          isOpen={!!pendingTx}
+          onClose={() => setPendingTx(null)}
+          type={pendingTx.type}
+          circleName={pendingTx.circle.name}
+          amount={pendingTx.amount}
+          onConfirm={() =>
+            pendingTx.type === "contribute"
+              ? submitContribution(pendingTx.circle, pendingTx.amount)
+              : submitClaim(pendingTx.circle)
+          }
+        />
+      )}
     </div>
   );
 }

--- a/components/cards/SavingsCard.tsx
+++ b/components/cards/SavingsCard.tsx
@@ -7,9 +7,13 @@ import type { Circle } from "@/types/circle";
 
 interface Props {
   circle: Circle;
+  onContribute: (circle: Circle) => void;
+  onClaim: (circle: Circle) => void;
 }
 
-export default function SavingsCard({ circle }: Props) {
+export default function SavingsCard({ circle, onContribute, onClaim }: Props) {
+  const claimDisabled = circle.claimButtonVariant === "disabled";
+
   return (
     <div className="bg-[#212124] p-6 md:p-8 rounded-3xl">
       <div className="flex flex-col md:flex-row md:items-start justify-between mb-8 gap-4">
@@ -74,16 +78,26 @@ export default function SavingsCard({ circle }: Props) {
       </div>
 
       <div className="flex flex-col sm:flex-row gap-4 mt-8 pt-6 border-t border-[#ffffff0f] shrink-0">
-        <button className="flex-1 sm:flex-none px-6 py-2.5 bg-[#4B6B76] hover:bg-[#3D5A64] text-white text-sm font-medium rounded-lg transition-colors text-center focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#4B6B76] focus-visible:ring-offset-2 focus-visible:ring-offset-[#212124]">
+        <button
+          type="button"
+          onClick={() => onContribute(circle)}
+          className="flex-1 sm:flex-none px-6 py-2.5 bg-[#4B6B76] hover:bg-[#3D5A64] text-white text-sm font-medium rounded-lg transition-colors text-center focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#4B6B76] focus-visible:ring-offset-2 focus-visible:ring-offset-[#212124]"
+        >
           {circle.contributionButtonLabel}
         </button>
         <button
+          type="button"
+          onClick={() => !claimDisabled && onClaim(circle)}
+          disabled={claimDisabled}
+          aria-disabled={claimDisabled}
           className={`flex-1 sm:flex-none px-6 py-2.5 text-sm font-medium rounded-lg transition-colors text-center ml-auto sm:ml-0 md:ml-auto focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#4B6B76] focus-visible:ring-offset-2 focus-visible:ring-offset-[#212124] ${
+            claimDisabled ? "cursor-not-allowed" : ""
+          } ${
             circle.claimButtonVariant === "primary"
               ? "bg-[#4B6B76] hover:bg-[#3D5A64] text-white"
               : circle.claimButtonVariant === "secondary"
               ? "bg-[#5E686A] hover:bg-[#4d5658] text-white"
-              : "bg-[#78787B] hover:bg-[#636366] text-[#E0E0E0]"
+              : "bg-[#78787B] text-[#E0E0E0]"
           }`}
         >
           Claim Reward

--- a/components/circles/OrganizerControls.tsx
+++ b/components/circles/OrganizerControls.tsx
@@ -1,0 +1,249 @@
+"use client";
+
+import { useState } from "react";
+
+/**
+ * Types — adjust these to match your actual Circle/Member types
+ * if you already have them defined elsewhere (e.g. types/circle.ts).
+ * Feel free to delete these and import the real ones instead.
+ */
+export interface CircleMember {
+  address: string;
+  displayName?: string;
+}
+
+export interface Circle {
+  id: string;
+  creatorAddress: string;
+  members: CircleMember[];
+  status: "active" | "closed";
+}
+
+interface OrganizerControlsProps {
+  circle: Circle;
+  connectedAddress?: string | null;
+  onRemoveMember: (address: string) => Promise<void> | void;
+  onCloseCircle: () => Promise<void> | void;
+  onExtendRound: (extraDays: number) => Promise<void> | void;
+}
+
+/**
+ * Small helper for case-insensitive address comparison.
+ */
+function isSameAddress(a?: string | null, b?: string | null) {
+  if (!a || !b) return false;
+  return a.toLowerCase() === b.toLowerCase();
+}
+
+/**
+ * A two-step confirm wrapper. First click arms the action and shows
+ * a confirm prompt; second click (within the same render) fires it.
+ * Satisfies "All destructive actions require a second confirmation step".
+ */
+function useConfirm() {
+  const [armedKey, setArmedKey] = useState<string | null>(null);
+
+  function requestConfirm(key: string) {
+    setArmedKey(key);
+  }
+
+  function cancel() {
+    setArmedKey(null);
+  }
+
+  function isArmed(key: string) {
+    return armedKey === key;
+  }
+
+  return { requestConfirm, cancel, isArmed };
+}
+
+export function OrganizerControls({
+  circle,
+  connectedAddress,
+  onRemoveMember,
+  onCloseCircle,
+  onExtendRound,
+}: OrganizerControlsProps) {
+  const isOrganizer = isSameAddress(connectedAddress, circle.creatorAddress);
+
+  const [showCloseModal, setShowCloseModal] = useState(false);
+  const [extendDays, setExtendDays] = useState(7);
+  const [busy, setBusy] = useState(false);
+  const removeConfirm = useConfirm();
+
+  // Read-only participants see nothing from this component.
+  if (!isOrganizer) {
+    return null;
+  }
+
+  async function handleRemove(address: string) {
+    setBusy(true);
+    try {
+      await onRemoveMember(address);
+    } finally {
+      setBusy(false);
+      removeConfirm.cancel();
+    }
+  }
+
+  async function handleConfirmedClose() {
+    setBusy(true);
+    try {
+      await onCloseCircle();
+    } finally {
+      setBusy(false);
+      setShowCloseModal(false);
+    }
+  }
+
+  async function handleExtend() {
+    setBusy(true);
+    try {
+      await onExtendRound(extendDays);
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <div className="rounded-lg border border-amber-300 bg-amber-50 p-4 space-y-4">
+      <div className="flex items-center gap-2">
+        <span className="text-xs font-semibold uppercase tracking-wide text-amber-700">
+          Organizer Controls
+        </span>
+        <span className="rounded-full bg-amber-200 px-2 py-0.5 text-[10px] font-medium text-amber-800">
+          You created this circle
+        </span>
+      </div>
+
+      {/* Member management */}
+      <div className="space-y-2">
+        <h3 className="text-sm font-medium text-gray-700">Participants</h3>
+        <ul className="divide-y divide-gray-200 rounded-md border border-gray-200 bg-white">
+          {circle.members.map((member) => {
+            const isCreator = isSameAddress(member.address, circle.creatorAddress);
+            const confirmKey = `remove-${member.address}`;
+            return (
+              <li
+                key={member.address}
+                className="flex items-center justify-between px-3 py-2"
+              >
+                <div className="flex items-center gap-2">
+                  <span className="text-sm font-mono text-gray-800">
+                    {member.displayName ?? member.address}
+                  </span>
+                  {isCreator && (
+                    <span className="rounded-full bg-blue-100 px-2 py-0.5 text-[10px] font-semibold text-blue-700">
+                      Organizer
+                    </span>
+                  )}
+                </div>
+
+                {!isCreator &&
+                  (removeConfirm.isArmed(confirmKey) ? (
+                    <div className="flex items-center gap-2">
+                      <span className="text-xs text-red-600">Remove this member?</span>
+                      <button
+                        type="button"
+                        disabled={busy}
+                        onClick={() => handleRemove(member.address)}
+                        className="rounded bg-red-600 px-2 py-1 text-xs font-medium text-white hover:bg-red-700 disabled:opacity-50"
+                      >
+                        Confirm
+                      </button>
+                      <button
+                        type="button"
+                        onClick={removeConfirm.cancel}
+                        className="rounded border border-gray-300 px-2 py-1 text-xs text-gray-600 hover:bg-gray-50"
+                      >
+                        Cancel
+                      </button>
+                    </div>
+                  ) : (
+                    <button
+                      type="button"
+                      onClick={() => removeConfirm.requestConfirm(confirmKey)}
+                      className="rounded border border-red-300 px-2 py-1 text-xs font-medium text-red-600 hover:bg-red-50"
+                    >
+                      Remove Member
+                    </button>
+                  ))}
+              </li>
+            );
+          })}
+        </ul>
+      </div>
+
+      {/* Extend round duration */}
+      <div className="flex items-center gap-2">
+        <h3 className="text-sm font-medium text-gray-700">Extend Round</h3>
+        <input
+          type="number"
+          min={1}
+          value={extendDays}
+          onChange={(e) => setExtendDays(Number(e.target.value))}
+          className="w-16 rounded border border-gray-300 px-2 py-1 text-sm"
+        />
+        <span className="text-xs text-gray-500">days</span>
+        <button
+          type="button"
+          disabled={busy}
+          onClick={handleExtend}
+          className="rounded bg-blue-600 px-3 py-1 text-xs font-medium text-white hover:bg-blue-700 disabled:opacity-50"
+        >
+          Extend
+        </button>
+      </div>
+
+      {/* Close circle */}
+      <div>
+        <button
+          type="button"
+          disabled={busy || circle.status === "closed"}
+          onClick={() => setShowCloseModal(true)}
+          className="rounded bg-red-700 px-3 py-1.5 text-xs font-semibold text-white hover:bg-red-800 disabled:opacity-50"
+        >
+          {circle.status === "closed" ? "Circle Closed" : "Close Circle Early"}
+        </button>
+      </div>
+
+      {showCloseModal && (
+        <div
+          role="dialog"
+          aria-modal="true"
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
+        >
+          <div className="w-full max-w-sm rounded-lg bg-white p-5 shadow-lg">
+            <h4 className="text-base font-semibold text-gray-900">
+              Close this circle early?
+            </h4>
+            <p className="mt-2 text-sm text-gray-600">
+              Closing the circle ends the current round immediately. Remaining
+              contributions will be settled according to the circle&apos;s payout
+              rules, and no further members can join or contribute. This action
+              cannot be undone.
+            </p>
+            <div className="mt-4 flex justify-end gap-2">
+              <button
+                type="button"
+                onClick={() => setShowCloseModal(false)}
+                className="rounded border border-gray-300 px-3 py-1.5 text-sm text-gray-700 hover:bg-gray-50"
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                disabled={busy}
+                onClick={handleConfirmedClose}
+                className="rounded bg-red-700 px-3 py-1.5 text-sm font-semibold text-white hover:bg-red-800 disabled:opacity-50"
+              >
+                Yes, close circle
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/components/modals/TxConfirmModal.tsx
+++ b/components/modals/TxConfirmModal.tsx
@@ -1,0 +1,201 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Loader2, CheckCircle2, XCircle, ExternalLink, X } from "lucide-react";
+
+export type TxType = "contribute" | "claim";
+export type TxStatus = "idle" | "pending" | "success" | "error";
+
+interface TxConfirmModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  type: TxType;
+  circleName: string;
+  amount: number; // USDT amount
+  /**
+   * Submits the actual on-chain transaction.
+   * Should resolve with the tx hash on success, or throw on failure.
+   */
+  onConfirm: () => Promise<string>;
+  /** Placeholder gas estimate; replace with a real estimate when available */
+  estimatedGasFee?: string;
+}
+
+const EXPLORER_BASE_URL = "https://starkscan.co/tx";
+
+export default function TxConfirmModal({
+  isOpen,
+  onClose,
+  type,
+  circleName,
+  amount,
+  onConfirm,
+  estimatedGasFee = "~0.0008 ETH",
+}: TxConfirmModalProps) {
+  const [status, setStatus] = useState<TxStatus>("idle");
+  const [txHash, setTxHash] = useState<string | null>(null);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (isOpen) {
+      setStatus("idle");
+      setTxHash(null);
+      setErrorMessage(null);
+    }
+  }, [isOpen]);
+
+  if (!isOpen) return null;
+
+  const actionLabel = type === "contribute" ? "Make Contribution" : "Claim Reward";
+  const actionVerb = type === "contribute" ? "contributing" : "claiming";
+
+  const handleConfirm = async () => {
+    setStatus("pending");
+    setErrorMessage(null);
+    try {
+      const hash = await onConfirm();
+      setTxHash(hash);
+      setStatus("success");
+    } catch (err) {
+      setErrorMessage(
+        err instanceof Error ? err.message : "Something went wrong. Please try again."
+      );
+      setStatus("error");
+    }
+  };
+
+  const handleClose = () => {
+    if (status === "pending") return; // prevent closing mid-transaction
+    onClose();
+  };
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/70 backdrop-blur-sm px-4"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="tx-confirm-title"
+      onClick={handleClose}
+    >
+      <div
+        className="w-full max-w-md rounded-2xl bg-[#1C1C1E] border border-[#ffffff14] p-6 shadow-xl font-sora"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="flex items-center justify-between mb-5">
+          <h2 id="tx-confirm-title" className="text-lg font-semibold text-white">
+            Confirm {actionLabel}
+          </h2>
+          {status !== "pending" && (
+            <button
+              onClick={handleClose}
+              aria-label="Close"
+              className="text-[#A1A1AA] hover:text-white transition-colors"
+            >
+              <X size={20} />
+            </button>
+          )}
+        </div>
+
+        {/* IDLE / PENDING REVIEW STATE */}
+        {(status === "idle" || status === "pending") && (
+          <>
+            <dl className="space-y-3 mb-6">
+              <div className="flex justify-between text-sm">
+                <dt className="text-[#A1A1AA]">Action</dt>
+                <dd className="font-medium text-white">{actionLabel}</dd>
+              </div>
+              <div className="flex justify-between text-sm">
+                <dt className="text-[#A1A1AA]">Circle</dt>
+                <dd className="font-medium text-white">{circleName}</dd>
+              </div>
+              <div className="flex justify-between text-sm">
+                <dt className="text-[#A1A1AA]">Amount</dt>
+                <dd className="font-medium text-white">{amount.toLocaleString()} USDT</dd>
+              </div>
+              <div className="flex justify-between text-sm">
+                <dt className="text-[#A1A1AA]">Estimated gas fee</dt>
+                <dd className="font-medium text-white">{estimatedGasFee}</dd>
+              </div>
+            </dl>
+
+            <div className="flex gap-3">
+              <button
+                onClick={handleClose}
+                disabled={status === "pending"}
+                className="flex-1 rounded-xl border border-[#ffffff1a] text-white py-2.5 font-medium hover:bg-[#ffffff0a] transition-colors disabled:opacity-50"
+              >
+                Cancel
+              </button>
+              <button
+                onClick={handleConfirm}
+                disabled={status === "pending"}
+                className="flex-1 flex items-center justify-center gap-2 rounded-xl bg-[#4ADE80] text-[#0A0A0A] py-2.5 font-semibold hover:bg-[#3fc873] transition-colors disabled:opacity-70"
+              >
+                {status === "pending" ? (
+                  <>
+                    <Loader2 size={18} className="animate-spin" />
+                    Confirming...
+                  </>
+                ) : (
+                  "Confirm"
+                )}
+              </button>
+            </div>
+          </>
+        )}
+
+        {/* SUCCESS STATE */}
+        {status === "success" && (
+          <div className="text-center py-2">
+            <CheckCircle2 className="mx-auto mb-3 text-[#4ADE80]" size={48} />
+            <p className="font-medium text-white mb-1">
+              {type === "contribute" ? "Contribution successful" : "Reward claimed"}
+            </p>
+            <p className="text-sm text-[#A1A1AA] mb-4">
+              Your {actionVerb} of {amount.toLocaleString()} USDT to {circleName} was confirmed.
+            </p>
+            {txHash && (
+              <a
+                href={`${EXPLORER_BASE_URL}/${txHash}`}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-flex items-center gap-1 text-[#4ADE80] hover:underline text-sm"
+              >
+                View on Starkscan <ExternalLink size={14} />
+              </a>
+            )}
+            <button
+              onClick={onClose}
+              className="mt-6 w-full rounded-xl bg-[#4ADE80] text-[#0A0A0A] py-2.5 font-semibold hover:bg-[#3fc873] transition-colors"
+            >
+              Done
+            </button>
+          </div>
+        )}
+
+        {/* ERROR STATE */}
+        {status === "error" && (
+          <div className="text-center py-2">
+            <XCircle className="mx-auto mb-3 text-red-500" size={48} />
+            <p className="font-medium text-white mb-1">Transaction failed</p>
+            <p className="text-sm text-[#A1A1AA] mb-6">{errorMessage}</p>
+            <div className="flex gap-3">
+              <button
+                onClick={onClose}
+                className="flex-1 rounded-xl border border-[#ffffff1a] text-white py-2.5 font-medium hover:bg-[#ffffff0a] transition-colors"
+              >
+                Cancel
+              </button>
+              <button
+                onClick={handleConfirm}
+                className="flex-1 rounded-xl bg-[#4ADE80] text-[#0A0A0A] py-2.5 font-semibold hover:bg-[#3fc873] transition-colors"
+              >
+                Retry
+              </button>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
# #25 feat: Add Transaction Confirmation Modal for Contributions and Claims

## Description

This PR introduces a transaction confirmation modal for contribution and reward claim actions. Before submitting an on-chain transaction, users are presented with a summary of the transaction details, allowing them to review and confirm the action. The modal also provides transaction status updates, success feedback, and error handling for a smoother user experience.

## Changes

- Added a reusable `TxConfirmModal` component.
- Displayed the modal when users click **Make Contribution** or **Claim Reward**.
- Included the following transaction details:
  - Action type
  - Circle name
  - USDT amount
  - Estimated gas fee (placeholder)
- Added **Confirm** and **Cancel** actions.
- Displayed a loading spinner while the transaction is pending.
- Added a success state with a clickable transaction hash linking to Starkscan.
- Added an error state with a retry option.
- Updated savings card actions to open the confirmation modal instead of immediately submitting transactions.
- Integrated the modal into `app/dashboard/page.tsx`.

## Why

Blockchain transactions are irreversible, making accidental submissions costly for users. Introducing a confirmation step improves user confidence, reduces mistakes, and provides clear feedback throughout the transaction lifecycle.

## Testing

- Verified the confirmation modal opens when **Make Contribution** or **Claim Reward** is clicked.
- Confirmed the correct transaction details are displayed.
- Verified **Confirm** submits the transaction and displays a loading state.
- Confirmed successful transactions display a clickable Starkscan transaction link.
- Verified failed transactions display an error message with a retry option.
- Confirmed transactions are only submitted after explicit user confirmation.

## Checklist

- [x] Code follows project standards.
- [x] Added and updated UI components.
- [x] Tested locally.
- [x] No breaking changes introduced.
- [x] Ready for review.

closes #25 
closes #28 