### PR TITLE
Feture/issue 18 27 29

### DIFF
--- a/app/dashboard/layout.tsx
+++ b/app/dashboard/layout.tsx
@@ -1,5 +1,5 @@
 import Link from "next/link";
-import { LayoutGrid, Lock, FileText, User, Settings, Users, LogOut } from "lucide-react";
+import { LayoutGrid, Lock, FileText, User, Settings, Users, LogOut, Wallet } from "lucide-react";
 import CopyButton from "@/components/ui/CopyButton";
 import MobileBottomNav from "@/components/layout/MobileBottomNav";
 import NotificationDropdown from "@/components/layout/NotificationDropdown";
@@ -54,6 +54,15 @@ export default function DashboardLayout({
                 >
                   <Lock size={20} aria-hidden="true" />
                   <span className="font-medium">Locked Funds</span>
+                </Link>
+              </li>
+              <li>
+                <Link
+                  href="/dashboard/payouts"
+                  className="flex items-center gap-3 px-4 py-3 text-[#9A9A9A] hover:text-[#EBEBEB] hover:bg-[#ffffff0a] rounded-lg transition-colors border-l-2 border-transparent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#4B6B76]"
+                >
+                  <Wallet size={20} aria-hidden="true" />
+                  <span className="font-medium">Payouts</span>
                 </Link>
               </li>
               <li>

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -3,6 +3,7 @@
 import { useMemo, useState } from "react";
 import { ArrowUpRight, Users, CheckCircle2, DollarSign } from "lucide-react";
 import SavingsCard from "@/components/cards/SavingsCard";
+import SavingsGrowthChart from "@/components/charts/SavingsGrowthChart";
 import TxConfirmModal, { TxType } from "@/components/modals/TxConfirmModal";
 import type { Circle } from "@/types/circle";
 
@@ -199,6 +200,8 @@ export default function DashboardOverviewPage() {
           </div>
         </div>
       </div>
+
+      <SavingsGrowthChart />
 
       {/* Active Savings Section */}
       <div>

--- a/app/dashboard/payouts/page.tsx
+++ b/app/dashboard/payouts/page.tsx
@@ -1,0 +1,262 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import Link from "next/link";
+import { ArrowUpRight, CheckCircle2, Clock3, ChevronDown } from "lucide-react";
+
+type PayoutStatus = "completed" | "pending";
+
+interface PayoutRecord {
+  transaction_hash: string;
+  circle_name: string;
+  amount: number;
+  token_symbol: string;
+  payout_date: string;
+  round_number: number;
+  status: PayoutStatus;
+}
+
+const MOCK_PAYOUT_HISTORY: PayoutRecord[] = [
+  {
+    transaction_hash: "0x8f41a8dd0a13cc9c5f8d25c8e2f2f2a34e1d0b4f0a5a9d6c7b8c9d0e1f2a3b4c",
+    circle_name: "Family Growth",
+    amount: 50,
+    token_symbol: "USDT",
+    payout_date: "2026-07-25T16:20:00Z",
+    round_number: 3,
+    status: "completed",
+  },
+  {
+    transaction_hash: "0x4c2f19ab31d8f4e5c9b0d7a23e1f4a8b6c5d4e3f2a1b09876543210fedcba98",
+    circle_name: "School Fees",
+    amount: 120,
+    token_symbol: "USDC",
+    payout_date: "2026-07-22T10:05:00Z",
+    round_number: 2,
+    status: "completed",
+  },
+  {
+    transaction_hash: "0x19d3b7f5a8c1e2d4f6b7a9c0d1e3f4a5b6c7d8e9f0a1234567890abcdef1234",
+    circle_name: "Car Repairs",
+    amount: 75,
+    token_symbol: "STRK",
+    payout_date: "2026-07-18T08:45:00Z",
+    round_number: 1,
+    status: "completed",
+  },
+  {
+    transaction_hash: "0x7b6a5d4c3e2f1a0b9c8d7e6f5a4b3c2d1e0f9a8b7c6d5e4f3210ab9cd8ef7654",
+    circle_name: "Wedding Fund",
+    amount: 200,
+    token_symbol: "USDT",
+    payout_date: "2026-07-10T14:00:00Z",
+    round_number: 4,
+    status: "completed",
+  },
+  {
+    transaction_hash: "0x2d4f6b8a1c3e5f7a9d0b2c4e6f8a1d3c5e7f9b0a2c4e6f8a1d3c5e7f9b0a2c4",
+    circle_name: "Community Project",
+    amount: 35,
+    token_symbol: "USDC",
+    payout_date: "2026-07-02T11:30:00Z",
+    round_number: 2,
+    status: "pending",
+  },
+  {
+    transaction_hash: "0x6e5d4c3b2a1908f7e6d5c4b3a291807f6e5d4c3b2a1908f7e6d5c4b3a291807",
+    circle_name: "Savings Challenge",
+    amount: 90,
+    token_symbol: "USDT",
+    payout_date: "2026-06-28T09:15:00Z",
+    round_number: 5,
+    status: "completed",
+  },
+  {
+    transaction_hash: "0x9a8b7c6d5e4f3210ab9cd8ef7654c3b2a1908f7e6d5c4b3a291807f6e5d4c3b",
+    circle_name: "Travel Fund",
+    amount: 150,
+    token_symbol: "STRK",
+    payout_date: "2026-06-19T07:55:00Z",
+    round_number: 1,
+    status: "completed",
+  },
+  {
+    transaction_hash: "0x3c5e7f9b0a2c4e6f8a1d3c5e7f9b0a2c4e6f8a1d3c5e7f9b0a2c4e6f8a1d3c",
+    circle_name: "Emergency Fund",
+    amount: 60,
+    token_symbol: "USDC",
+    payout_date: "2026-06-11T18:40:00Z",
+    round_number: 6,
+    status: "pending",
+  },
+];
+
+const PAGE_SIZE = 5;
+
+function formatAmount(amount: number, tokenSymbol: string) {
+  return `${amount.toLocaleString()} ${tokenSymbol}`;
+}
+
+function formatDate(dateValue: string) {
+  return new Intl.DateTimeFormat("en-US", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  }).format(new Date(dateValue));
+}
+
+function truncateHash(hash: string) {
+  return `${hash.slice(0, 8)}...${hash.slice(-6)}`;
+}
+
+function statusStyles(status: PayoutStatus) {
+  if (status === "completed") {
+    return "bg-[#1f3b2d] text-[#8ef0b0] border-[#2d5c43]";
+  }
+
+  return "bg-[#3a2f18] text-[#ffd56a] border-[#665221]";
+}
+
+export default function PayoutsPage() {
+  const [visibleCount, setVisibleCount] = useState(PAGE_SIZE);
+
+  const visiblePayouts = useMemo(
+    () => MOCK_PAYOUT_HISTORY.slice(0, visibleCount),
+    [visibleCount]
+  );
+
+  const hasMore = visibleCount < MOCK_PAYOUT_HISTORY.length;
+
+  return (
+    <div className="space-y-8 pb-20 md:pb-0">
+      <div className="flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
+        <div>
+          <p className="text-sm font-medium uppercase tracking-[0.2em] text-[#9A9A9A]">
+            Trustless transparency
+          </p>
+          <h1 className="mt-2 text-3xl font-bold font-sora text-white">
+            Payout history
+          </h1>
+          <p className="mt-3 max-w-2xl text-sm leading-6 text-[#C7C7C7]">
+            Review every completed and pending payout from your circles. Each
+            transaction links directly to the blockchain for independent
+            verification.
+          </p>
+        </div>
+
+        <div className="rounded-2xl border border-[#ffffff14] bg-[#1C1C1E] px-4 py-3 text-sm text-[#C7C7C7]">
+          <span className="font-semibold text-white">{MOCK_PAYOUT_HISTORY.length}</span> total payouts
+        </div>
+      </div>
+
+      <section className="overflow-hidden rounded-3xl border border-[#ffffff12] bg-[#18181A] shadow-[0_24px_80px_rgba(0,0,0,0.35)]">
+        {MOCK_PAYOUT_HISTORY.length === 0 ? (
+          <div className="flex min-h-[320px] flex-col items-center justify-center px-6 text-center">
+            <div className="mb-4 flex h-14 w-14 items-center justify-center rounded-full border border-[#ffffff14] bg-[#ffffff08] text-white">
+              <CheckCircle2 size={24} aria-hidden="true" />
+            </div>
+            <h2 className="text-xl font-semibold text-white">No payouts yet</h2>
+            <p className="mt-2 max-w-md text-sm leading-6 text-[#A1A1AA]">
+              When your circles start distributing funds, the full payout
+              history will appear here with transaction links for verification.
+            </p>
+          </div>
+        ) : (
+          <>
+            <div className="overflow-x-auto">
+              <table className="min-w-full divide-y divide-[#ffffff0f]">
+                <thead className="bg-[#ffffff05] text-left text-xs uppercase tracking-[0.18em] text-[#9A9A9A]">
+                  <tr>
+                    <th scope="col" className="px-6 py-4 font-medium">
+                      Circle Name
+                    </th>
+                    <th scope="col" className="px-6 py-4 font-medium">
+                      Amount
+                    </th>
+                    <th scope="col" className="px-6 py-4 font-medium">
+                      Date
+                    </th>
+                    <th scope="col" className="px-6 py-4 font-medium">
+                      Round #
+                    </th>
+                    <th scope="col" className="px-6 py-4 font-medium">
+                      Transaction Hash
+                    </th>
+                    <th scope="col" className="px-6 py-4 font-medium">
+                      Status
+                    </th>
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-[#ffffff0f] bg-[#18181A]">
+                  {visiblePayouts.map((payout) => (
+                    <tr key={payout.transaction_hash} className="transition-colors hover:bg-[#ffffff06]">
+                      <td className="px-6 py-4 text-sm font-medium text-white">
+                        {payout.circle_name}
+                      </td>
+                      <td className="px-6 py-4 text-sm text-[#E5E5E5]">
+                        {formatAmount(payout.amount, payout.token_symbol)}
+                      </td>
+                      <td className="px-6 py-4 text-sm text-[#C7C7C7]">
+                        {formatDate(payout.payout_date)}
+                      </td>
+                      <td className="px-6 py-4 text-sm text-[#C7C7C7]">
+                        {payout.round_number}
+                      </td>
+                      <td className="px-6 py-4 text-sm">
+                        <Link
+                          href={`https://starkscan.co/tx/${payout.transaction_hash}`}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="inline-flex items-center gap-1 text-[#8FC7FF] transition-colors hover:text-white"
+                          aria-label={`Open transaction ${payout.transaction_hash} in a new tab`}
+                        >
+                          <span className="font-mono">
+                            {truncateHash(payout.transaction_hash)}
+                          </span>
+                          <ArrowUpRight size={14} aria-hidden="true" />
+                        </Link>
+                      </td>
+                      <td className="px-6 py-4 text-sm">
+                        <span
+                          className={`inline-flex items-center gap-1 rounded-full border px-2.5 py-1 text-xs font-semibold uppercase tracking-[0.16em] ${statusStyles(
+                            payout.status
+                          )}`}
+                        >
+                          {payout.status === "completed" ? (
+                            <CheckCircle2 size={12} aria-hidden="true" />
+                          ) : (
+                            <Clock3 size={12} aria-hidden="true" />
+                          )}
+                          {payout.status === "completed" ? "Completed" : "Pending"}
+                        </span>
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+
+            <div className="flex items-center justify-between gap-4 border-t border-[#ffffff0f] px-6 py-4">
+              <p className="text-sm text-[#A1A1AA]">
+                Showing {visiblePayouts.length} of {MOCK_PAYOUT_HISTORY.length} payouts
+              </p>
+
+              {hasMore ? (
+                <button
+                  type="button"
+                  onClick={() => setVisibleCount((current) => current + PAGE_SIZE)}
+                  className="inline-flex items-center gap-2 rounded-full border border-[#ffffff16] bg-[#ffffff08] px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-[#ffffff10] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#4B6B76]"
+                >
+                  Load more
+                  <ChevronDown size={16} aria-hidden="true" />
+                </button>
+              ) : (
+                <span className="text-sm text-[#A1A1AA]">All payouts loaded</span>
+              )}
+            </div>
+          </>
+        )}
+      </section>
+    </div>
+  );
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import "./global.css";
 import Providers from "./providers";
+import Toaster from "@/components/ui/Toaster";
 
 export const metadata: Metadata = {
   title: "Ahjoor — Save With Friends",
@@ -22,7 +23,10 @@ export default function RootLayout({
   return (
     <html lang="en" suppressHydrationWarning>
       <body suppressHydrationWarning>
-        <Providers>{children}</Providers>
+        <Providers>
+          <Toaster />
+          {children}
+        </Providers>
       </body>
     </html>
   );

--- a/app/providers.tsx
+++ b/app/providers.tsx
@@ -1,7 +1,12 @@
 "use client";
 
 import { WalletProvider } from "@/contexts/WalletContext";
+import { ToastProvider } from "@/components/ui/Toast";
 
 export default function Providers({ children }: { children: React.ReactNode }) {
-  return <WalletProvider>{children}</WalletProvider>;
+  return (
+    <WalletProvider>
+      <ToastProvider>{children}</ToastProvider>
+    </WalletProvider>
+  );
 }

--- a/components/charts/SavingsGrowthChart.tsx
+++ b/components/charts/SavingsGrowthChart.tsx
@@ -1,0 +1,246 @@
+"use client";
+
+import { useMemo, useState } from "react";
+
+type Timeframe = "7D" | "30D" | "All Time";
+
+interface ChartPoint {
+  label: string;
+  value: number;
+  tooltipDate: string;
+}
+
+const DATA: Record<Timeframe, ChartPoint[]> = {
+  "7D": [
+    { label: "Mon", value: 180, tooltipDate: "Mon, Jul 21" },
+    { label: "Tue", value: 260, tooltipDate: "Tue, Jul 22" },
+    { label: "Wed", value: 340, tooltipDate: "Wed, Jul 23" },
+    { label: "Thu", value: 390, tooltipDate: "Thu, Jul 24" },
+    { label: "Fri", value: 520, tooltipDate: "Fri, Jul 25" },
+    { label: "Sat", value: 610, tooltipDate: "Sat, Jul 26" },
+    { label: "Sun", value: 760, tooltipDate: "Sun, Jul 27" },
+  ],
+  "30D": [
+    { label: "W1", value: 180, tooltipDate: "Week of Jun 30" },
+    { label: "W2", value: 310, tooltipDate: "Week of Jul 7" },
+    { label: "W3", value: 480, tooltipDate: "Week of Jul 14" },
+    { label: "W4", value: 690, tooltipDate: "Week of Jul 21" },
+    { label: "W5", value: 860, tooltipDate: "Week of Jul 28" },
+    { label: "W6", value: 1040, tooltipDate: "Week of Aug 4" },
+  ],
+  "All Time": [
+    { label: "Jan", value: 90, tooltipDate: "January" },
+    { label: "Feb", value: 180, tooltipDate: "February" },
+    { label: "Mar", value: 260, tooltipDate: "March" },
+    { label: "Apr", value: 430, tooltipDate: "April" },
+    { label: "May", value: 580, tooltipDate: "May" },
+    { label: "Jun", value: 720, tooltipDate: "June" },
+    { label: "Jul", value: 980, tooltipDate: "July" },
+  ],
+};
+
+const TIMEFRAMES: Timeframe[] = ["7D", "30D", "All Time"];
+
+function buildPath(points: Array<{ x: number; y: number }>) {
+  if (points.length === 0) return "";
+
+  return points.map((point, index) => `${index === 0 ? "M" : "L"}${point.x},${point.y}`).join(" ");
+}
+
+function buildAreaPath(points: Array<{ x: number; y: number }>, baselineY: number) {
+  if (points.length === 0) return "";
+
+  const path = buildPath(points);
+  const lastPoint = points[points.length - 1];
+  const firstPoint = points[0];
+
+  return `${path} L ${lastPoint.x},${baselineY} L ${firstPoint.x},${baselineY} Z`;
+}
+
+export default function SavingsGrowthChart() {
+  const [timeframe, setTimeframe] = useState<Timeframe>("30D");
+  const [hoveredPoint, setHoveredPoint] = useState<number | null>(null);
+
+  const data = DATA[timeframe];
+
+  const { linePath, areaPath, plottedPoints, maxValue, minValue } = useMemo(() => {
+    const width = 100;
+    const height = 100;
+    const paddingX = 6;
+    const paddingY = 12;
+    const availableWidth = width - paddingX * 2;
+    const availableHeight = height - paddingY * 2;
+    const max = Math.max(...data.map((point) => point.value));
+    const min = Math.min(...data.map((point) => point.value));
+    const range = Math.max(max - min, 1);
+
+    const points = data.map((point, index) => {
+      const x =
+        data.length === 1
+          ? width / 2
+          : paddingX + (availableWidth * index) / (data.length - 1);
+      const normalized = (point.value - min) / range;
+      const y = height - paddingY - normalized * availableHeight;
+
+      return { x, y };
+    });
+
+    return {
+      linePath: buildPath(points),
+      areaPath: buildAreaPath(points, height - paddingY),
+      plottedPoints: points,
+      maxValue: max,
+      minValue: min,
+    };
+  }, [data]);
+
+  const activePoint = hoveredPoint !== null ? data[hoveredPoint] : null;
+  const activeCoords = hoveredPoint !== null ? plottedPoints[hoveredPoint] : null;
+
+  return (
+    <section className="rounded-2xl bg-[#1C1C1E] p-6 shadow-[0_20px_70px_rgba(0,0,0,0.28)]">
+      <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+        <div>
+          <p className="text-sm font-medium uppercase tracking-[0.2em] text-[#9A9A9A]">
+            Savings growth
+          </p>
+          <h2 className="mt-2 text-xl font-bold font-sora text-white">
+            Cumulative savings over time
+          </h2>
+          <p className="mt-2 text-sm text-[#A1A1AA]">
+            Track how your USDT savings have grown across the selected timeframe.
+          </p>
+        </div>
+
+        <div className="inline-flex rounded-full border border-[#ffffff14] bg-[#ffffff07] p-1 self-start">
+          {TIMEFRAMES.map((option) => {
+            const isActive = option === timeframe;
+
+            return (
+              <button
+                key={option}
+                type="button"
+                onClick={() => {
+                  setTimeframe(option);
+                  setHoveredPoint(null);
+                }}
+                className={`rounded-full px-4 py-2 text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#4B6B76] ${
+                  isActive
+                    ? "bg-white text-[#111111]"
+                    : "text-[#A1A1AA] hover:text-white"
+                }`}
+              >
+                {option}
+              </button>
+            );
+          })}
+        </div>
+      </div>
+
+      <div className="mt-6 relative">
+        <div className="absolute right-0 top-0 z-10 rounded-2xl border border-[#ffffff12] bg-[#111111] px-4 py-3 text-right shadow-lg">
+          <p className="text-[11px] uppercase tracking-[0.16em] text-[#9A9A9A]">{activePoint.label}</p>
+          <p className="mt-1 text-lg font-semibold text-white">{activePoint.value.toLocaleString()} USDT</p>
+          <p className="text-xs text-[#A1A1AA]">{activePoint.tooltipDate}</p>
+        </div>
+
+        <div className="h-[320px] w-full overflow-hidden rounded-[1.5rem] border border-[#ffffff10] bg-[#151516] p-4 sm:p-6">
+          <svg
+            viewBox="0 0 100 100"
+            preserveAspectRatio="none"
+            className="h-full w-full overflow-visible"
+            role="img"
+            aria-label={`Cumulative savings chart for ${timeframe}`}
+            onMouseLeave={() => setHoveredPoint(null)}
+          >
+            <defs>
+              <linearGradient id="savings-area-fill" x1="0" y1="0" x2="0" y2="1">
+                <stop offset="0%" stopColor="#5EEAD4" stopOpacity="0.35" />
+                <stop offset="100%" stopColor="#5EEAD4" stopOpacity="0.02" />
+              </linearGradient>
+              <linearGradient id="savings-line-stroke" x1="0" y1="0" x2="1" y2="0">
+                <stop offset="0%" stopColor="#5EEAD4" />
+                <stop offset="100%" stopColor="#8B5CF6" />
+              </linearGradient>
+            </defs>
+
+            {[0, 25, 50, 75, 100].map((tick) => (
+              <line
+                key={tick}
+                x1="0"
+                x2="100"
+                y1={tick}
+                y2={tick}
+                stroke="rgba(255,255,255,0.06)"
+                strokeDasharray="2 4"
+              />
+            ))}
+
+            <line x1="0" x2="100" y1="88" y2="88" stroke="rgba(255,255,255,0.14)" />
+            <line x1="8" x2="8" y1="0" y2="88" stroke="rgba(255,255,255,0.08)" />
+
+            <path d={areaPath} fill="url(#savings-area-fill)" />
+            <path
+              d={linePath}
+              fill="none"
+              stroke="url(#savings-line-stroke)"
+              strokeWidth="2.5"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            />
+
+            {plottedPoints.map((point, index) => {
+              const isActive = hoveredPoint === index;
+
+              return (
+                <g key={data[index].label}>
+                  <circle
+                    cx={point.x}
+                    cy={point.y}
+                    r={isActive ? 2.8 : 1.8}
+                    fill="#E5E7EB"
+                  />
+                  <circle
+                    cx={point.x}
+                    cy={point.y}
+                    r={6}
+                    fill="transparent"
+                    onMouseEnter={() => setHoveredPoint(index)}
+                    onFocus={() => setHoveredPoint(index)}
+                    tabIndex={0}
+                  />
+                </g>
+              );
+            })}
+          </svg>
+
+          <div className="mt-3 grid grid-cols-2 gap-2 text-xs text-[#A1A1AA] sm:grid-cols-4 lg:grid-cols-7">
+            {data.map((point) => (
+              <div key={point.label} className="text-center">
+                <div className="font-medium text-white">{point.label}</div>
+                <div>{point.value.toLocaleString()} USDT</div>
+              </div>
+            ))}
+          </div>
+        </div>
+
+        {activePoint && activeCoords && (
+          <div
+            className="pointer-events-none absolute z-20 hidden rounded-xl border border-[#ffffff14] bg-[#111111] px-3 py-2 text-xs text-white shadow-xl sm:block"
+            style={{
+              left: `calc(${activeCoords.x}% + 12px)`,
+              top: `calc(${activeCoords.y}% + 18px)`,
+            }}
+          >
+            <div className="font-medium text-[#5EEAD4]">{activePoint.tooltipDate}</div>
+            <div>{activePoint.value.toLocaleString()} USDT</div>
+          </div>
+        )}
+
+        <div className="mt-3 text-xs text-[#A1A1AA]">
+          Range: {minValue.toLocaleString()} to {maxValue.toLocaleString()} USDT
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/components/ui/Toast.tsx
+++ b/components/ui/Toast.tsx
@@ -1,0 +1,137 @@
+"use client";
+
+import { createContext, useCallback, useContext, useMemo, useState } from "react";
+import { AlertCircle, CheckCircle2, Info, TriangleAlert } from "lucide-react";
+
+export type ToastVariant = "success" | "error" | "warning" | "info";
+
+export interface ToastInput {
+  title: string;
+  message?: string;
+  variant?: ToastVariant;
+}
+
+export interface ToastItem extends Required<Pick<ToastInput, "title">> {
+  id: string;
+  message?: string;
+  variant: ToastVariant;
+  phase: "entering" | "visible" | "leaving";
+}
+
+export interface ToastContextValue {
+  toasts: ToastItem[];
+  showToast: (toast: ToastInput) => string;
+  dismissToast: (id: string) => void;
+}
+
+const ToastContext = createContext<ToastContextValue | null>(null);
+
+const AUTO_DISMISS_MS = 4000;
+const EXIT_ANIMATION_MS = 220;
+
+function createToastId() {
+  return `${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
+}
+
+export function ToastProvider({ children }: { children: React.ReactNode }) {
+  const [toasts, setToasts] = useState<ToastItem[]>([]);
+
+  const dismissToast = useCallback((id: string) => {
+    setToasts((current) =>
+      current.map((toast) => (toast.id === id ? { ...toast, phase: "leaving" } : toast))
+    );
+
+    window.setTimeout(() => {
+      setToasts((current) => current.filter((toast) => toast.id !== id));
+    }, EXIT_ANIMATION_MS);
+  }, []);
+
+  const showToast = useCallback((toast: ToastInput) => {
+    const id = createToastId();
+    const nextToast: ToastItem = {
+      id,
+      title: toast.title,
+      message: toast.message,
+      variant: toast.variant ?? "info",
+      phase: "entering",
+    };
+
+    setToasts((current) => [...current, nextToast]);
+
+    window.setTimeout(() => {
+      setToasts((current) =>
+        current.map((item) => (item.id === id ? { ...item, phase: "visible" } : item))
+      );
+    }, 20);
+
+    window.setTimeout(() => {
+      setToasts((current) =>
+        current.some((item) => item.id === id)
+          ? current.map((item) =>
+              item.id === id ? { ...item, phase: "leaving" } : item
+            )
+          : current
+      );
+
+      window.setTimeout(() => {
+        setToasts((current) => current.filter((item) => item.id !== id));
+      }, EXIT_ANIMATION_MS);
+    }, AUTO_DISMISS_MS);
+
+    return id;
+  }, []);
+
+  const value = useMemo(
+    () => ({ toasts, showToast, dismissToast }),
+    [toasts, showToast, dismissToast]
+  );
+
+  return <ToastContext.Provider value={value}>{children}</ToastContext.Provider>;
+}
+
+export function useToast() {
+  const context = useContext(ToastContext);
+  if (!context) {
+    throw new Error("useToast must be used within ToastProvider");
+  }
+
+  return context;
+}
+
+export function toastVariantStyles(variant: ToastVariant) {
+  switch (variant) {
+    case "success":
+      return {
+        ring: "ring-emerald-500/25",
+        accent: "bg-emerald-500/15 text-emerald-300",
+        title: "text-emerald-50",
+        message: "text-emerald-100/80",
+        icon: CheckCircle2,
+      };
+    case "error":
+      return {
+        ring: "ring-rose-500/25",
+        accent: "bg-rose-500/15 text-rose-300",
+        title: "text-rose-50",
+        message: "text-rose-100/80",
+        icon: AlertCircle,
+      };
+    case "warning":
+      return {
+        ring: "ring-amber-500/25",
+        accent: "bg-amber-500/15 text-amber-300",
+        title: "text-amber-50",
+        message: "text-amber-100/80",
+        icon: TriangleAlert,
+      };
+    case "info":
+    default:
+      return {
+        ring: "ring-sky-500/25",
+        accent: "bg-sky-500/15 text-sky-300",
+        title: "text-sky-50",
+        message: "text-sky-100/80",
+        icon: Info,
+      };
+  }
+}

--- a/components/ui/Toaster.tsx
+++ b/components/ui/Toaster.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import { X } from "lucide-react";
+import { toastVariantStyles, useToast } from "@/components/ui/Toast";
+
+export default function Toaster() {
+  const { toasts, dismissToast } = useToast();
+
+  return (
+    <div className="pointer-events-none fixed right-4 top-4 z-[100] flex w-[calc(100vw-2rem)] max-w-sm flex-col gap-3 sm:right-6 sm:top-6 sm:w-full">
+      {toasts.map((toast) => {
+        const styles = toastVariantStyles(toast.variant);
+        const Icon = styles.icon;
+
+        return (
+          <article
+            key={toast.id}
+            role="alert"
+            aria-live="polite"
+            className={`pointer-events-auto transform rounded-2xl border border-white/10 bg-[#161616] p-4 shadow-[0_20px_60px_rgba(0,0,0,0.45)] ring-1 ${styles.ring} transition-all duration-200 ease-out ${
+              toast.phase === "entering"
+                ? "translate-x-4 opacity-0"
+                : toast.phase === "leaving"
+                  ? "translate-x-3 opacity-0"
+                  : "translate-x-0 opacity-100"
+            }`}
+          >
+            <div className="flex items-start gap-3">
+              <div className={`mt-0.5 flex h-10 w-10 items-center justify-center rounded-full ${styles.accent}`}>
+                <Icon size={18} aria-hidden="true" />
+              </div>
+
+              <div className="min-w-0 flex-1">
+                <div className={`text-sm font-semibold ${styles.title}`}>{toast.title}</div>
+                {toast.message && (
+                  <p className={`mt-1 text-sm leading-5 ${styles.message}`}>{toast.message}</p>
+                )}
+              </div>
+
+              <button
+                type="button"
+                onClick={() => dismissToast(toast.id)}
+                className="rounded-full p-1 text-[#A1A1AA] transition-colors hover:bg-white/5 hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#4B6B76]"
+                aria-label="Dismiss toast"
+              >
+                <X size={16} aria-hidden="true" />
+              </button>
+            </div>
+          </article>
+        );
+      })}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
Adds a new `/dashboard/payouts` page with a mock payout history table, transaction links to Starkscan, status badges, and load-more behavior. Also adds a savings growth chart to the dashboard overview and a global toast/snackbar system for app-wide feedback.

close #18 
close #27 
close #29 
## What changed
- Added `/dashboard/payouts` route and sidebar navigation entry
- Added a dark-themed savings growth chart on the dashboard overview
- Added a global toast system mounted at the app root
- Used mock data structures for payouts and chart data for now

## Notes
- No dependencies were installed
- No verification was run, per request